### PR TITLE
Added support for newer docker-compose versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,29 @@
 sudo: required
+dist: xenial
 language: python
 cache: pip
-python: 3.6
+python: 3.7
 services:
   - docker
 env:
   - TOX_ENV=lint
-  - TOX_ENV=py36-compose7
-  - TOX_ENV=py36-compose8
-  - TOX_ENV=py36-compose9
-  - TOX_ENV=py36-compose10
-  - TOX_ENV=py36-compose11
-  - TOX_ENV=py36-compose12
-  - TOX_ENV=py36-compose13
-  - TOX_ENV=py36-compose14
-  - TOX_ENV=py36-compose15
-  - TOX_ENV=py36-compose16
-  - TOX_ENV=py36-compose17
-  - TOX_ENV=py36-compose18
-  - TOX_ENV=py36-compose19
+  - TOX_ENV=py37-compose7
+  - TOX_ENV=py37-compose8
+  - TOX_ENV=py37-compose9
+  - TOX_ENV=py37-compose10
+  - TOX_ENV=py37-compose11
+  - TOX_ENV=py37-compose12
+  - TOX_ENV=py37-compose13
+  - TOX_ENV=py37-compose14
+  - TOX_ENV=py37-compose15
+  - TOX_ENV=py37-compose16
+  - TOX_ENV=py37-compose17
+  - TOX_ENV=py37-compose18
+  - TOX_ENV=py37-compose19
+  - TOX_ENV=py37-compose20
+  - TOX_ENV=py37-compose21
+  - TOX_ENV=py37-compose22
+  - TOX_ENV=py37-compose23
   - TOX_ENV=compose-master
 install: travis_retry pip install tox
 script: tox -e $TOX_ENV

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,8 @@
+# Authors
+
+- Frank Sachsenheim - Original Author -
+  [<img src="https://github.githubassets.com/favicon.ico" height="15px" />](https://github.com/funkyfuture)
+
+- Erik Wolf -
+  [<img src="https://github.githubassets.com/favicon.ico" height="15px" />](https://github.com/3mb3dw0rk5)
+

--- a/compose_dump/backup.py
+++ b/compose_dump/backup.py
@@ -1,5 +1,5 @@
-from collections import OrderedDict, Sequence
-from collections.abc import Mapping
+from collections import OrderedDict
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from io import StringIO
 import logging
@@ -232,8 +232,7 @@ def store_project_volumes(ctx):
                 continue
             bits, stat = ctx.project.client.get_archive(container.id, path)
             archive_name = name + '.tar'
-            if hasattr(bits, 'stream'):
-                # older docker-apis (< 3.0.0) do not return a data generator
+            if hasattr(bits, 'stream'):  # TODO: obsolete with docker-compose>1.19.0 (e.g. docker-py>=3.0.0)
                 bits = bits.stream
             ctx.storage.write_file(bits, archive_name, namespace='volumes/project')
             ctx.manifest['volumes']['project'][name] = archive_name
@@ -277,8 +276,7 @@ def store_services_volumes(ctx, mounted_paths):
             for path in internal_volumes:
                 archive_name = hash_string(service.name.upper() + path) + '.tar'
                 bits, stat = ctx.project.client.get_archive(container.id, path)
-                if hasattr(bits, 'stream'):
-                    # older docker-apis (< 3.0.0) do not return a data generator
+                if hasattr(bits, 'stream'):  # TODO: obsolete with docker-compose>1.19.0 (e.g. docker-py>=3.0.0)
                     bits = bits.stream
                 ctx.storage.write_file(bits, archive_name, namespace='volumes/services')
                 index[path] = archive_name

--- a/compose_dump/backup.py
+++ b/compose_dump/backup.py
@@ -1,4 +1,5 @@
-from collections import Mapping, OrderedDict, Sequence
+from collections import OrderedDict, Sequence
+from collections.abc import Mapping
 from datetime import datetime
 from io import StringIO
 import logging

--- a/compose_dump/backup.py
+++ b/compose_dump/backup.py
@@ -182,6 +182,8 @@ def put_config_file(ctx, filepath, considered_files):
 
 def store_build_contexts(ctx):
     project_dir = ctx.options['project_dir']
+    # create set of paths to copy to avoid duplicated copies
+    config_dirs = set()
 
     for service in ctx.project.services:
         if service.name not in ctx.options['services']:
@@ -193,7 +195,10 @@ def store_build_contexts(ctx):
         context = build_options.get('context')
         if context:
             dst = Path(context).relative_to(project_dir)
-            ctx.storage.put_folder(project_dir / context, dst, namespace='config')
+            config_dirs.add((project_dir / context, dst))
+
+    for config_dir in config_dirs:
+        ctx.storage.put_folder(config_dir[0], config_dir[1], namespace='config')
 
 
 ####

--- a/compose_dump/main.py
+++ b/compose_dump/main.py
@@ -58,7 +58,7 @@ def parse_cli_args(args):
 
 def add_backup_parser(subparsers):
     desc, hlp = backup.__doc__.split('####\n')
-    parser = subparsers.add_parser('backup', description=desc, help=hlp)
+    parser = subparsers.add_parser('backup', description=desc.strip(), help=hlp.strip())
     parser.set_defaults(action=backup)
     parser.add_argument('--config', action='store_true', default=False,
                         help='Include configuration files, including referenced files '

--- a/compose_dump/storage.py
+++ b/compose_dump/storage.py
@@ -118,7 +118,7 @@ class ArchiveStorage(StorageAdapterBase):
         if isinstance(data, bytes):
             size = len(data)
             buffer = io.BytesIO(data)
-        elif callable(data):
+        elif callable(data):  # TODO: obsolete with docker-compose>1.19.0 (e.g. docker-py>=3.0.0)
             size = 0
             buffer = io.BytesIO()
             for chunk in data():
@@ -175,7 +175,7 @@ class FolderStorage(StorageAdapterBase):
         elif isinstance(data, bytes):
             with dst.open('wb') as f:
                 f.write(data)
-        elif callable(data):
+        elif callable(data):  # TODO: obsolete with docker-compose>1.19.0 (e.g. docker-py>=3.0.0)
             with dst.open('wb') as f:
                 for chunk in data():
                     f.write(chunk)

--- a/compose_dump/storage.py
+++ b/compose_dump/storage.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import shutil
 import sys
 import tarfile
+import types
 from time import time
 
 from compose_dump.utils import hash_string
@@ -124,6 +125,13 @@ class ArchiveStorage(StorageAdapterBase):
                 size += len(chunk)
                 buffer.write(chunk)
             buffer.seek(0)
+        elif isinstance(data, types.GeneratorType):
+            size = 0
+            buffer = io.BytesIO()
+            for chunk in data:
+                size += len(chunk)
+                buffer.write(chunk)
+            buffer.seek(0)
 
         tarinfo = tarfile.TarInfo(str(dst))
         tarinfo.size = size
@@ -170,6 +178,10 @@ class FolderStorage(StorageAdapterBase):
         elif callable(data):
             with dst.open('wb') as f:
                 for chunk in data():
+                    f.write(chunk)
+        elif isinstance(data, types.GeneratorType):
+            with dst.open('wb') as f:
+                for chunk in data:
                     f.write(chunk)
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@
 from setuptools import setup, find_packages
 import sys
 
-VERSION = '0.1-beta4'
+VERSION = '0.1-beta5'
 
 
-if sys.version_info < (3, 6):
-    raise AssertionError('Requires Python 3.6 or later.')
+if sys.version_info < (3, 5):
+    raise AssertionError('Requires Python 3.5 or later.')
 
 
 setup(
@@ -36,7 +36,7 @@ setup(
     author_email='funkyfuture@riseup.net',
     license='ISC',
     platforms=["any"],
-    install_requires=['docker-compose>=1.7,<1.20'],
+    install_requires=['docker-compose>=1.7'],
     tests_require=['tox'],
     packages=find_packages(exclude=['tests.*', 'tests']),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email='funkyfuture@riseup.net',
     license='ISC',
     platforms=["any"],
-    install_requires=['docker-compose>=1.7'],
+    install_requires=['docker-compose>=1.7,<=1.24'],
     tests_require=['tox'],
     packages=find_packages(exclude=['tests.*', 'tests']),
     include_package_data=True,

--- a/tests/fixtures/projects/config_with_duplicated_build_context/context/asset.txt
+++ b/tests/fixtures/projects/config_with_duplicated_build_context/context/asset.txt
@@ -1,0 +1,1 @@
+Lorem ipsum

--- a/tests/fixtures/projects/config_with_duplicated_build_context/docker-compose.yml
+++ b/tests/fixtures/projects/config_with_duplicated_build_context/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+services:
+  custom:
+    build:
+      context: ./context
+
+  custom2:
+    build:
+      context: ./context

--- a/tests/integrations/test_backup_config.py
+++ b/tests/integrations/test_backup_config.py
@@ -57,6 +57,12 @@ def test_config_with_build_context_v2(project_dir, temp_dir):
     assert identical_folder_contents(project_dir, target_folder / 'config')
 
 
+def test_config_with_duplicated_build_context(project_dir, temp_dir):
+    assert result_okay(['backup', '-t', str(temp_dir)])
+    target_folder = get_target_folder(temp_dir)
+    assert identical_folder_contents(project_dir, target_folder / 'config')
+
+
 @mark.parametrize('resolve_symlinks', (True, False))
 def test_nested_extends(project_dir, temp_dir, resolve_symlinks):
     args = ['backup', '-t', str(temp_dir)]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36-compose{7,8,9,10,11,12,13,14,15,16,17,18,19},compose-master,lint
+envlist = py37-compose{7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,future},compose-master,lint
 
 [testenv]
 commands = pytest {posargs} tests
@@ -10,6 +10,7 @@ deps =
     compose8: docker-compose>=1.8,<1.9
     compose9: docker-compose>=1.9,<1.10
     compose10: docker-compose>=1.10,<1.11
+    compose10: pip<10.0
     compose11: docker-compose>=1.11,<1.12
     compose12: docker-compose>=1.12,<1.13
     compose13: docker-compose>=1.13,<1.14
@@ -19,6 +20,11 @@ deps =
     compose17: docker-compose>=1.17,<1.18
     compose18: docker-compose>=1.18,<1.19
     compose19: docker-compose>=1.19,<1.20
+    compose20: docker-compose>=1.20,<1.21
+    compose21: docker-compose>=1.21,<1.22
+    compose22: docker-compose>=1.22,<1.23
+    compose23: docker-compose>=1.23,<1.24
+    composefuture: docker-compose>=1.24
 
 [testenv:compose-master]
 commands = pytest {posargs} tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37-compose{7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,future},compose-master,lint
+envlist = py37-compose{7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23},compose-master,lint
 
 [testenv]
 commands = pytest {posargs} tests
@@ -24,7 +24,6 @@ deps =
     compose21: docker-compose>=1.21,<1.22
     compose22: docker-compose>=1.22,<1.23
     compose23: docker-compose>=1.23,<1.24
-    composefuture: docker-compose>=1.24
 
 [testenv:compose-master]
 commands = pytest {posargs} tests


### PR DESCRIPTION
Started using your project which is what I was looking for a long time to backup my server configurations.

So I started to align the code with the current docker-compose and docker-api releases. Also moved on to use python 3.7.

Hope these fixes help others as well. I would also contribute to further feature implementations like restore procedure, removing the backup-memory limitation etc.